### PR TITLE
feat: Issue #14 sayHellow Agent Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Agent output files
+hello_output.md
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Ruff
+.ruff_cache/

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,12 +1,23 @@
-# Current task plan
+# Current task plan - Issue #14: sayHello Agent
 
 ## Goal
-******
+sayHelloカスタムエージェントを呼び出し、ワークスペースルートに`hello_output.md`ファイルを生成する機能を実装
+
+## Implementation Details
+1. `src/agents/say_hello.py`: sayHello エージェントのメイン実装
+   - エージェント呼び出し時にトリガー
+   - ルートディレクトリに `hello_output.md` を生成
+   - ファイルに現在の日時と挨拶メッセージを記録
+2. `tests/test_say_hello.py`: エージェント機能のテスト
+   - ファイル生成確認
+   - ファイル内容確認
 
 ## Files to change
-- src/***
-- tests/test_***
+- src/agents/__init__.py (新規/更新)
+- src/agents/say_hello.py (新規)
+- tests/test_say_hello.py (新規)
 
 ## Risks
 - 既存レスポンス形式を変えない
 - 既存テストを壊さない
+- ルートに意図しないファイルを生成しない

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+"""
+herness Application Package
+"""

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,9 @@
+"""
+Agents Package
+
+カスタムエージェント機能を提供するパッケージです。
+"""
+
+from .say_hello import say_hello
+
+__all__ = ["say_hello"]

--- a/src/agents/say_hello.py
+++ b/src/agents/say_hello.py
@@ -1,0 +1,55 @@
+"""
+sayHello Agent Module
+
+このモジュールは、sayHelloエージェントを実装しています。
+呼び出されると、ワークスペースのルートに hello_output.md ファイルを生成します。
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+def say_hello(root_dir: Optional[str] = None) -> str:
+    """
+    sayHello エージェントの実行関数
+    
+    エージェント呼び出し時にトリガーし、ワークスペースのルートに
+    hello_output.md ファイルを生成します。
+    
+    Args:
+        root_dir: ファイル生成先のルートディレクトリ。
+                  Noneの場合はカレントワーキングディレクトリを使用。
+    
+    Returns:
+        実行結果メッセージ
+    """
+    if root_dir is None:
+        root_dir = "."
+    
+    # ルートディレクトリのパスを設定
+    root_path = Path(root_dir)
+    output_file = root_path / "hello_output.md"
+    
+    # 現在の日時を取得
+    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    
+    # ファイルの内容を生成
+    content = f"""# Hello Output
+
+**Time**: {current_time}
+**Message**: さようなら、エージェント呼び出し完了
+
+---
+Created by: sayHello Agent
+"""
+    
+    # ファイルを生成
+    output_file.write_text(content, encoding="utf-8")
+    
+    return f"hello_output.md generated at {output_file.absolute()}"
+
+
+if __name__ == "__main__":
+    result = say_hello()
+    print(result)

--- a/tests/test_say_hello.py
+++ b/tests/test_say_hello.py
@@ -1,0 +1,85 @@
+"""
+Tests for sayHello Agent
+
+sayHello エージェントのテストモジュール
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.agents import say_hello
+
+
+class TestSayHello:
+    """sayHello エージェントのテストクラス"""
+    
+    def test_say_hello_creates_file(self) -> None:
+        """
+        say_hello が指定ディレクトリに hello_output.md を生成することを確認
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = say_hello(root_dir=tmpdir)
+            
+            # ファイルが生成されていることを確認
+            output_file = Path(tmpdir) / "hello_output.md"
+            assert output_file.exists(), "hello_output.md ファイルが生成されていません"
+            
+            # 結果メッセージが返されていることを確認
+            assert "hello_output.md generated" in result
+            assert str(output_file) in result
+    
+    def test_say_hello_file_content(self) -> None:
+        """
+        生成されたファイルの内容が正しいことを確認
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            say_hello(root_dir=tmpdir)
+            
+            output_file = Path(tmpdir) / "hello_output.md"
+            content = output_file.read_text(encoding="utf-8")
+            
+            # ファイル内容に必要な要素が含まれていることを確認
+            assert "# Hello Output" in content
+            assert "**Time**:" in content
+            assert "**Message**: さようなら、エージェント呼び出し完了" in content
+            assert "Created by: sayHello Agent" in content
+    
+    def test_say_hello_file_has_timestamp(self) -> None:
+        """
+        生成されたファイルにタイムスタンプが含まれていることを確認
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            say_hello(root_dir=tmpdir)
+            
+            output_file = Path(tmpdir) / "hello_output.md"
+            content = output_file.read_text(encoding="utf-8")
+            
+            # タイムスタンプが含まれていることを確認（YYYY-MM-DD HH:MM:SS形式）
+            import re
+            timestamp_pattern = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            assert re.search(timestamp_pattern, content), "タイムスタンプが見つかりません"
+    
+    def test_say_hello_default_dir(self) -> None:
+        """
+        say_hello が引数なしで呼び出された場合、カレントディレクトリに生成されることを確認
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # 一時ディレクトリをカレントディレクトリにして実行
+            import os
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                result = say_hello()
+                
+                # ファイルが生成されていることを確認
+                output_file = Path(tmpdir) / "hello_output.md"
+                assert output_file.exists(), "hello_output.md ファイルが生成されていません"
+                assert "hello_output.md generated" in result
+            finally:
+                os.chdir(original_cwd)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Issue #14: sayHello Agent Implementation

## 概要
sayHelloカスタムエージェント機能を実装しました。

## 実装内容
- src/agents/say_hello.py: sayHelloエージェントのメイン実装
- src/agents/__init__.py: agentsパッケージ初期化
- src/__init__.py: srcパッケージ初期化
- tests/test_say_hello.py: 4つの包括的なテスト
- .gitignore: エージェント出力ファイル除外

## 検証状況
✅ テスト: 4/4 テスト通過
✅ Lint: Ruff チェック通過
✅ 型チェック: mypy 通過
✅ エージェント実行確認: ルートに hello_output.md が正常に生成される